### PR TITLE
Use requests to find the list of graphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-pnp",
   "types": ["module"],
-  "version": "1.0",
+  "version": "1.1",
   "homepage": "http://github.com/shinken-monitoring/mod-ui-pnp",
   "author": "Jean Gabès",
   "description": "Enable PNP4Nagios graphs inside the WebUI",
@@ -9,6 +9,10 @@
     {
       "name": "Jean Gabès",
       "email": "naparuba@gmail.com"
+    },
+    {
+      "name": "Guillaume Subiron",
+      "email": "maethor@subiron.org"
     }
   ],
   "repository": "https://github.com/shinken-monitoring/mod-ui-pnp",


### PR DESCRIPTION
Hi,

The current mod-ui-pnp return a list based on the number of metrics in the perfdata. This is wrong because:
- On the same service, the perfdata can be absent in some state and present in other.
- PNP4Nagios can be use to regroup many metrics in one graph.

This PR proposes to use requests to find the true list of graphs by testing one by one the URL until it finds one that doesn't work. It is not ideal but I believe it is better than the current behavior.

@naparuba if you want I can be manager of this repository and owner of the shinken.io package. I think it would make sense since this is only related to the webui.